### PR TITLE
Use ssh via AWS Session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ terraform -chdir=infrastructure plan
 terraform -chdir=infrastructure apply
 ```
 
+### use this command to output changes to aws
+```bash
+terraform -chdir=infrastructure output
+``
+
 ### use this command after terraform apply
 ```bash
 # Setup SSH via Session Manager (one-time per user)

--- a/README.md
+++ b/README.md
@@ -35,19 +35,47 @@ terraform -chdir=infrastructure apply
 terraform -chdir=infrastructure output
 ```
 
-### use this command to import an existing instance in AWS ECS
-### find the instance id in the aws console
-```bash
-terraform import aws_instance.main {i-00000abcdef11111}
-```
-
-### use this command to ssh into the EC2 via Session Manager
-```bash
-aws ssm start-session --target {i-00000abcdef11111}
-```
-
 ### Install the AWS session manager 
 ```bash
  brew install --cask session-manager-plugin
 ```
 
+### use this command to list all AWS EC2 instances in the terminal
+```bash
+aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,State.Name,Tags[?Key==`Name`].Value|[0],IamInstanceProfile.Arn]' --output table
+```
+
+### use the following command to import an existing instance in AWS EC2
+### first, clear the old aws instance state just to be safe
+### then let terraform know which main EC2 instance to save in state
+### find the instance id in the EC2 instance in the AWS Console UI
+### or use the following command to list all existing AWS EC2 instances
+```bash
+terraform state rm aws_instance.main
+terraform import aws_instance.main {i-00000abcdef11111}
+```
+### IMPORTANT: When first creating the EC2 instance, terraform runs a user data script located in main.tf 
+
+```bash 
+#!/bin/bash
+yum update -y                              # Update the system
+yum install -y httpd amazon-ssm-agent      # Install web server + SSM agent
+systemctl start httpd amazon-ssm-agent     # Start both services
+systemctl enable httpd amazon-ssm-agent    # Enable them to start on boot
+echo "<h1>Hello from ${var.instance_name}</h1>" > /var/www/html/index.html
+echo "Instance setup completed at $(date)" >> /var/log/setup.log
+echo "SSH-via-Session-Manager enabled" >> /var/log/setup.log
+```
+# What This Script Does:
+* Updates the system (can take 5-15 minutes)
+* Installs the SSM agent (amazon-ssm-agent package)
+* Starts the SSM agent (systemctl start amazon-ssm-agent)
+* Enables it to auto-start on future reboots
+
+Please note that it might take up to 5-15 minutes, before user can ssh into the EC2 via Session Manager, as descibed in the step above
+
+
+### use this command to ssh into the EC2 via Session Manager
+```bash
+aws ssm start-session --target {i-00000abcdef11111}
+```

--- a/README.md
+++ b/README.md
@@ -33,13 +33,21 @@ terraform -chdir=infrastructure apply
 ### use this command to output changes to aws
 ```bash
 terraform -chdir=infrastructure output
-``
-
-### use this command after terraform apply
-```bash
-# Setup SSH via Session Manager (one-time per user)
-terraform -chdir=infrastructure output ssh_via_session_manager_setup
-
-# Connect using SSH through Session Manager
-ssh -i ~/.ssh/session-manager-key ec2-user@$(terraform -chdir=infrastructure output -raw instance_id)
 ```
+
+### use this command to import an existing instance in AWS ECS
+### find the instance id in the aws console
+```bash
+terraform import aws_instance.main {i-00000abcdef11111}
+```
+
+### use this command to ssh into the EC2 via Session Manager
+```bash
+aws ssm start-session --target {i-00000abcdef11111}
+```
+
+### Install the AWS session manager 
+```bash
+ brew install --cask session-manager-plugin
+```
+

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ terraform -chdir=infrastructure apply
 
 ### use this command after terraform apply
 ```bash
-terraform -chdir=infrastructure output -raw ssh_private_key > ~/.ssh/rukmer-commons-ec2-key
+# Setup SSH via Session Manager (one-time per user)
+terraform -chdir=infrastructure output ssh_via_session_manager_setup
 
-chmod 600 ~/.ssh/rukmer-commons-ec2-key
-
-ssh -i ~/.ssh/rukmer-commons-ec2-key ec2-user@$(terraform -chdir=infrastructure output -raw ec2_public_ip)
+# Connect using SSH through Session Manager
+ssh -i ~/.ssh/session-manager-key ec2-user@$(terraform -chdir=infrastructure output -raw instance_id)
 ```

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -229,8 +229,6 @@ resource "aws_iam_role_policy_attachment" "ec2_session_manager_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
-
-
 resource "aws_iam_instance_profile" "ec2_session_manager_profile" {
   name = "${var.project_name}-ec2-session-manager-profile"
   role = aws_iam_role.ec2_session_manager_role.name

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,32 +8,27 @@ locals {
     Environment = var.environment
   }
   
-  # Reference to the S3 bucket (either created or existing)
-  artifacts_bucket_id = var.create_bucket ? aws_s3_bucket.artifacts[0].id : data.aws_s3_bucket.artifacts[0].id
+  # Reference to the S3 bucket
+  artifacts_bucket_id = aws_s3_bucket.artifacts.id
 }
 
 # ---------------------------------------------
 # S3 Bucket for App Assets
 # ---------------------------------------------
+
+# Create bucket - Terraform will manage it going forward
 resource "aws_s3_bucket" "artifacts" {
-  count  = var.create_bucket ? 1 : 0
-  bucket = "${var.project_name}-artifacts-${var.environment}"
+  bucket = var.existing_bucket_name
   tags   = local.tags
 
   lifecycle {
-    prevent_destroy = true
+    # prevent_destroy = true  # Temporarily disabled for destroy
     ignore_changes = [
       bucket,
       tags,
     ]
   }
 }
-
-data "aws_s3_bucket" "artifacts" {
-  count  = var.create_bucket ? 0 : 1
-  bucket = "${var.project_name}-artifacts-${var.environment}"
-}
-
 
 resource "aws_s3_bucket_cors_configuration" "artifacts" {
   bucket = local.artifacts_bucket_id
@@ -137,54 +132,13 @@ resource "aws_security_group" "ec2_sg" {
   description = "Security group for EC2 instance"
   vpc_id      = aws_vpc.main.id
 
-  # ---------------------------------------------
-  # LEGACY SSH ACCESS (Traditional SSH on port 22)
-  # TODO: REMOVE WHEN DEPRECATING BACKWARD COMPATIBILITY
-  # ---------------------------------------------
-  dynamic "ingress" {
-    for_each = var.enable_backward_compatibility ? [1] : []
-    content {
-      description = "[LEGACY] SSH access for backward compatibility"
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]  # ⚠️ Security risk - restrict this in production
-    }
-  }
-
-  # HTTP access
-  ingress {
-    description = "HTTP"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # HTTPS access
-  ingress {
-    description = "HTTPS"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # All outbound traffic
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = {
     Name = "${var.instance_name}-sg"
   }
 }
 
 # ---------------------------------------------
-# EC2 Instance - MODERN (Session Manager enabled)
+# EC2 Instance - MODERN Session Manager enabled
 # ---------------------------------------------
 resource "aws_instance" "main" {
   ami                    = data.aws_ami.amazon_linux.id
@@ -204,131 +158,39 @@ resource "aws_instance" "main" {
               
               # Log setup completion
               echo "Instance setup completed at $(date)" >> /var/log/setup.log
-              echo "[MODERN] SSH-via-Session-Manager enabled" >> /var/log/setup.log
-              ${var.enable_backward_compatibility ? "echo '[LEGACY] Backward compatibility mode enabled' >> /var/log/setup.log" : ""}
+              echo "SSH-via-Session-Manager enabled" >> /var/log/setup.log
               EOF
 
   tags = {
     Name = var.instance_name
-    AccessMethod = var.enable_backward_compatibility ? "[LEGACY+MODERN] SSH + Session Manager" : "[MODERN] Session Manager Only"
+    AccessMethod = "Session Manager Only"
   }
 }
 
 # ---------------------------------------------
-# IAM Roles for EC2 - MODERN (Session Manager)
+# IAM Roles for EC2 - Session Manager
 # REQUIRED: These enable the EC2 instance to communicate with Session Manager
 # ---------------------------------------------
 
-# Data source for existing IAM role (if using existing resources)
+# Data source for existing IAM role
 data "aws_iam_role" "existing_ec2_role" {
-  count = var.use_existing_iam_resources ? 1 : 0
-  name  = var.existing_ec2_role_name
+  name = var.existing_ec2_role_name
 }
 
-# Create new IAM role (if not using existing resources)
-resource "aws_iam_role" "ec2_session_manager_role" {
-  count = var.use_existing_iam_resources ? 0 : 1
-  name  = "${var.project_name}-ec2-session-manager-role"
-  
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = { Service = "ec2.amazonaws.com" }
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "ec2_session_manager_policy" {
-  count      = var.use_existing_iam_resources ? 0 : 1
-  role       = aws_iam_role.ec2_session_manager_role[0].name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_instance_profile" "ec2_session_manager_profile" {
-  count = var.use_existing_iam_resources ? 0 : 1
-  name  = "${var.project_name}-ec2-session-manager-profile"
-  role  = aws_iam_role.ec2_session_manager_role[0].name
-}
-
-# Local value to reference the correct role (existing or created)
+# Local value to reference existing IAM resources
 locals {
-  # Only set instance profile if we have IAM resources (either existing or created)
-  has_iam_resources = var.use_existing_iam_resources || length(var.iam_ssh_users) > 0
-  ec2_role_name = var.use_existing_iam_resources ? data.aws_iam_role.existing_ec2_role[0].name : (length(var.iam_ssh_users) > 0 ? aws_iam_role.ec2_session_manager_role[0].name : null)
-  instance_profile_name = var.use_existing_iam_resources ? var.existing_ec2_role_name : (length(var.iam_ssh_users) > 0 ? aws_iam_instance_profile.ec2_session_manager_profile[0].name : null)
+  # Always use existing IAM resources
+  has_iam_resources = length(var.iam_ssh_users) > 0
+  ec2_role_name = data.aws_iam_role.existing_ec2_role.name 
+  instance_profile_name = var.existing_ec2_role_name
 }
 
-
-# ---------------------------------------------
-# IAM User Access - MODERN (Session Manager SSH for Users)
-# RECOMMENDED: This grants your existing IAM users permission to SSH via Session Manager
-# 
-# How it works:
-# 1. Add your existing IAM usernames to var.iam_ssh_users in terraform.tfvars
-# 2. Terraform creates a policy that allows Session Manager access to THIS specific EC2 instance
-# 3. Terraform creates a group and adds your users to it
-# 4. Your users can now SSH using: aws ssm start-session --target INSTANCE_ID
-# ---------------------------------------------
-
-# Create the Session Manager access policy (only if not using existing resources)
-resource "aws_iam_policy" "ssh_session_manager_policy" {
-  count       = var.use_existing_iam_resources ? 0 : 1
-  name        = "${var.project_name}-ssh-session-manager-policy"
-  description = "Policy allowing SSH access to ${var.project_name} EC2 instance via Session Manager"
-  
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowSessionManagerSSH"
-        Effect = "Allow"
-        Action = "ssm:StartSession"
-        Resource = [
-          "arn:aws:ec2:${var.region}:*:instance/${aws_instance.main.id}",
-          "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
-        ]
-      },
-      {
-        Sid      = "AllowSessionManagerMessaging"
-        Effect   = "Allow"
-        Action   = "ssmmessages:OpenDataChannel"
-        Resource = "arn:aws:ssm:*:*:session/$${aws:userid}-*"
-      },
-      {
-        Sid    = "AllowInstanceDiscovery"
-        Effect = "Allow"
-        Action = [
-          "ssm:DescribeInstanceInformation",
-          "ec2:DescribeInstances"
-        ]
-        Resource = "*"
-      }
-    ]
-  })
-
-  tags = local.tags
-}
-
-# Data sources for existing IAM resources (if using existing resources)
+# Data source for existing IAM group
 data "aws_iam_group" "existing_user_group" {
-  count      = var.use_existing_iam_resources && length(var.iam_ssh_users) > 0 ? 1 : 0
+  count      = length(var.iam_ssh_users) > 0 ? 1 : 0
   group_name = var.existing_user_group_name
 }
 
-# Create IAM group for users who need SSH access (only if not using existing resources)
-resource "aws_iam_group" "ssh_session_users" {
-  count = var.use_existing_iam_resources ? 0 : (length(var.iam_ssh_users) > 0 ? 1 : 0)
-  name  = "${var.project_name}-ssh-session-users"
-}
-
-# Attach the policy to the group (only if not using existing resources)
-resource "aws_iam_group_policy_attachment" "ssh_session_policy" {
-  count      = var.use_existing_iam_resources ? 0 : (length(var.iam_ssh_users) > 0 ? 1 : 0)
-  group      = aws_iam_group.ssh_session_users[0].name
-  policy_arn = aws_iam_policy.ssh_session_manager_policy[0].arn
-}
 # ---------------------------------------------
 # Cognito User Pool for Marketplace API Authentication
 # ---------------------------------------------

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -191,7 +191,7 @@ resource "aws_instance" "main" {
   instance_type          = "t2.micro"
   vpc_security_group_ids = [aws_security_group.ec2_sg.id]
   subnet_id              = aws_subnet.public.id
-  iam_instance_profile   = aws_iam_instance_profile.ec2_session_manager_profile.name # [MODERN] Session Manager access
+  iam_instance_profile   = local.instance_profile_name # [MODERN] Session Manager access (optional)
   
   # Enhanced user data for both access methods
   user_data = <<-EOF
@@ -218,8 +218,17 @@ resource "aws_instance" "main" {
 # IAM Roles for EC2 - MODERN (Session Manager)
 # REQUIRED: These enable the EC2 instance to communicate with Session Manager
 # ---------------------------------------------
+
+# Data source for existing IAM role (if using existing resources)
+data "aws_iam_role" "existing_ec2_role" {
+  count = var.use_existing_iam_resources ? 1 : 0
+  name  = var.existing_ec2_role_name
+}
+
+# Create new IAM role (if not using existing resources)
 resource "aws_iam_role" "ec2_session_manager_role" {
-  name = "${var.project_name}-ec2-session-manager-role"
+  count = var.use_existing_iam_resources ? 0 : 1
+  name  = "${var.project_name}-ec2-session-manager-role"
   
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -232,15 +241,94 @@ resource "aws_iam_role" "ec2_session_manager_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "ec2_session_manager_policy" {
-  role       = aws_iam_role.ec2_session_manager_role.name
+  count      = var.use_existing_iam_resources ? 0 : 1
+  role       = aws_iam_role.ec2_session_manager_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_instance_profile" "ec2_session_manager_profile" {
-  name = "${var.project_name}-ec2-session-manager-profile"
-  role = aws_iam_role.ec2_session_manager_role.name
+  count = var.use_existing_iam_resources ? 0 : 1
+  name  = "${var.project_name}-ec2-session-manager-profile"
+  role  = aws_iam_role.ec2_session_manager_role[0].name
 }
 
+# Local value to reference the correct role (existing or created)
+locals {
+  # Only set instance profile if we have IAM resources (either existing or created)
+  has_iam_resources = var.use_existing_iam_resources || length(var.iam_ssh_users) > 0
+  ec2_role_name = var.use_existing_iam_resources ? data.aws_iam_role.existing_ec2_role[0].name : (length(var.iam_ssh_users) > 0 ? aws_iam_role.ec2_session_manager_role[0].name : null)
+  instance_profile_name = var.use_existing_iam_resources ? var.existing_ec2_role_name : (length(var.iam_ssh_users) > 0 ? aws_iam_instance_profile.ec2_session_manager_profile[0].name : null)
+}
+
+
+# ---------------------------------------------
+# IAM User Access - MODERN (Session Manager SSH for Users)
+# RECOMMENDED: This grants your existing IAM users permission to SSH via Session Manager
+# 
+# How it works:
+# 1. Add your existing IAM usernames to var.iam_ssh_users in terraform.tfvars
+# 2. Terraform creates a policy that allows Session Manager access to THIS specific EC2 instance
+# 3. Terraform creates a group and adds your users to it
+# 4. Your users can now SSH using: aws ssm start-session --target INSTANCE_ID
+# ---------------------------------------------
+
+# Create the Session Manager access policy (only if not using existing resources)
+resource "aws_iam_policy" "ssh_session_manager_policy" {
+  count       = var.use_existing_iam_resources ? 0 : 1
+  name        = "${var.project_name}-ssh-session-manager-policy"
+  description = "Policy allowing SSH access to ${var.project_name} EC2 instance via Session Manager"
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSessionManagerSSH"
+        Effect = "Allow"
+        Action = "ssm:StartSession"
+        Resource = [
+          "arn:aws:ec2:${var.region}:*:instance/${aws_instance.main.id}",
+          "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
+        ]
+      },
+      {
+        Sid      = "AllowSessionManagerMessaging"
+        Effect   = "Allow"
+        Action   = "ssmmessages:OpenDataChannel"
+        Resource = "arn:aws:ssm:*:*:session/$${aws:userid}-*"
+      },
+      {
+        Sid    = "AllowInstanceDiscovery"
+        Effect = "Allow"
+        Action = [
+          "ssm:DescribeInstanceInformation",
+          "ec2:DescribeInstances"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+# Data sources for existing IAM resources (if using existing resources)
+data "aws_iam_group" "existing_user_group" {
+  count      = var.use_existing_iam_resources && length(var.iam_ssh_users) > 0 ? 1 : 0
+  group_name = var.existing_user_group_name
+}
+
+# Create IAM group for users who need SSH access (only if not using existing resources)
+resource "aws_iam_group" "ssh_session_users" {
+  count = var.use_existing_iam_resources ? 0 : (length(var.iam_ssh_users) > 0 ? 1 : 0)
+  name  = "${var.project_name}-ssh-session-users"
+}
+
+# Attach the policy to the group (only if not using existing resources)
+resource "aws_iam_group_policy_attachment" "ssh_session_policy" {
+  count      = var.use_existing_iam_resources ? 0 : (length(var.iam_ssh_users) > 0 ? 1 : 0)
+  group      = aws_iam_group.ssh_session_users[0].name
+  policy_arn = aws_iam_policy.ssh_session_manager_policy[0].arn
+}
 # ---------------------------------------------
 # Cognito User Pool for Marketplace API Authentication
 # ---------------------------------------------
@@ -316,62 +404,4 @@ resource "aws_cognito_user_group" "publisher" {
   description  = "Publisher group with access to publishing features"
   user_pool_id = aws_cognito_user_pool.main.id
   precedence   = 2
-}
-
-# ---------------------------------------------
-# IAM User Access - MODERN (Session Manager SSH for Users)
-# RECOMMENDED: This grants your existing IAM users permission to SSH via Session Manager
-# ---------------------------------------------
-resource "aws_iam_policy" "ssh_session_manager_policy" {
-  count = length(var.iam_ssh_users) > 0 ? 1 : 0
-  name  = "${var.project_name}-ssh-session-manager-policy"
-  
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = "ssm:StartSession"
-        Resource = [
-          "arn:aws:ec2:${var.region}:*:instance/${aws_instance.main.id}",
-          "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = "ssmmessages:OpenDataChannel"
-        Resource = "arn:aws:ssm:*:*:session/$${aws:userid}-*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "ssm:DescribeInstanceInformation",
-          "ec2:DescribeInstances"
-        ]
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-# IAM group for SSH via Session Manager users
-resource "aws_iam_group" "ssh_session_users" {
-  count = length(var.iam_ssh_users) > 0 ? 1 : 0
-  name  = "${var.project_name}-ssh-session-users"
-}
-
-# Attach policy to group
-resource "aws_iam_group_policy_attachment" "ssh_session_policy" {
-  count      = length(var.iam_ssh_users) > 0 ? 1 : 0
-  group      = aws_iam_group.ssh_session_users[0].name
-  policy_arn = aws_iam_policy.ssh_session_manager_policy[0].arn
-}
-
-# Add IAM users to group
-resource "aws_iam_group_membership" "ssh_session_membership" {
-  count = length(var.iam_ssh_users) > 0 ? 1 : 0
-  name  = "${var.project_name}-ssh-session-membership"
-  
-  users = var.iam_ssh_users
-  group = aws_iam_group.ssh_session_users[0].name
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -178,8 +178,6 @@ resource "aws_instance" "main" {
   subnet_id              = aws_subnet.public.id
   iam_instance_profile   = aws_iam_instance_profile.ec2_session_manager_profile.name
   
-  # Backward compatibility: use existing key if specified
-  key_name = var.enable_backward_compatibility && var.existing_ssh_key_name != "" ? var.existing_ssh_key_name : null
 
   # Enhanced user data for both access methods
   user_data = <<-EOF

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -13,32 +13,30 @@ output "instance_id" {
   value       = aws_instance.main.id
 }
 
-output "ssh_via_session_manager_setup" {
-  description = "Simple setup instructions for SSH via Session Manager"
+output "connect_to_instance" {
+  description = "How to connect to your EC2 instance"
   value = <<-EOT
-    SSH via Session Manager Setup (one-time per user):
+    Connect to EC2 Instance via Session Manager:
 
-    1. Install Session Manager plugin:
+    1. Install Session Manager plugin (one-time):
        brew install --cask session-manager-plugin
 
-    2. Add to ~/.ssh/config:
-       Host i-* mi-*
-           ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
-           User ec2-user
-
-    3. Generate SSH key:
-       ssh-keygen -t rsa -b 4096 -f ~/.ssh/session-manager-key
-
-    4. Connect:
-       ssh -i ~/.ssh/session-manager-key ec2-user@${aws_instance.main.id}
+    2. Connect to your instance:
+       aws ssm start-session --target ${aws_instance.main.id}
 
     ✅ Uses your existing AWS IAM credentials
     ✅ No SSH ports open to internet
     ✅ Individual authentication & audit trails
+    ✅ Works immediately - no key setup required
   EOT
 }
 
 output "authorized_users" {
   description = "IAM users authorized for SSH access"
   value = length(var.iam_ssh_users) > 0 ? var.iam_ssh_users : ["No users configured - add to iam_ssh_users variable"]
+}
+
+output "connection_command" {
+  description = "Ready-to-use command to connect to your instance"
+  value = "aws ssm start-session --target ${aws_instance.main.id}"
 }

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -6,12 +6,18 @@ allowed_origins = ["http://localhost:4000", ""]
 create_bucket = false
 
 instance_name = "you_instance_name"
+# ---------------------------------------------
+# SSH Access Configuration
+# ---------------------------------------------
+
+# LEGACY: Traditional SSH (set to false to disable backward compatibility)
+# enable_backward_compatibility = true
+
+# MODERN: Session Manager SSH (recommended approach)
 iam_ssh_users = [
   # Add your existing IAM usernames here:
-  # Everytime a developer deploys, they need to
-  # keep this list updated. Each deployment
-  # can determine a list of users who collectively
-  # can SSH into the rukmer-commons-ec2-instance
+  # Each deployment can determine a list of users who collectively
+  # can SSH into the EC2 instance via AWS Session Manager
 
   # "your-iam-username",
   # "coworker-iam-username"

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -14,11 +14,22 @@ instance_name = "you_instance_name"
 # enable_backward_compatibility = true
 
 # MODERN: Session Manager SSH (recommended approach)
+# Just list your existing IAM usernames - Terraform handles the rest!
 iam_ssh_users = [
-  # Add your existing IAM usernames here:
-  # Each deployment can determine a list of users who collectively
-  # can SSH into the EC2 instance via AWS Session Manager
-
-  # "your-iam-username",
-  # "coworker-iam-username"
+  # Example usernames (replace with your actual IAM users):
+  # "john.doe",
+  # "jane.smith", 
+  # "developer1"
+  
+  # How to find your IAM username:
+  # Run: aws sts get-caller-identity --query "UserId" --output text
+  # Or check in AWS Console > IAM > Users
 ]
+
+# ---------------------------------------------
+# OPTION: Use Existing IAM Resources (if you get IAM permission errors)
+# ---------------------------------------------
+
+
+existing_ec2_role_name = "ask_for_ec2_role_that_lets_ec2_connect_with_session_manager"
+existing_user_group_name = "ask_for_the_group_name_that_allows_iam_users_to_connect_to_ec2"

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -6,14 +6,9 @@ allowed_origins = ["http://localhost:4000", ""]
 create_bucket = false
 
 instance_name = "you_instance_name"
-# ---------------------------------------------
-# SSH Access Configuration
-# ---------------------------------------------
+existing_bucket_name = "your_existing_bucket_name"
 
-# LEGACY: Traditional SSH (set to false to disable backward compatibility)
-# enable_backward_compatibility = true
-
-# MODERN: Session Manager SSH (recommended approach)
+# Session Manager SSH (recommended approach)
 # Just list your existing IAM usernames - Terraform handles the rest!
 iam_ssh_users = [
   # Example usernames (replace with your actual IAM users):

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -3,13 +3,15 @@ project_name = "rukmer-commons"
 environment = "prod"
 client_domain = ""
 allowed_origins = ["http://localhost:4000", ""]
+create_bucket = false
 
 instance_name = "you_instance_name"
 iam_ssh_users = [
   # Add your existing IAM usernames here:
   # Everytime a developer deploys, they need to
-  # keep this list updated. Each subsequent deployment
-  # will determine who can SSH into the rukmer-commons-ec2-instance.
+  # keep this list updated. Each deployment
+  # can determine a list of users who collectively
+  # can SSH into the rukmer-commons-ec2-instance
 
   # "your-iam-username",
   # "coworker-iam-username"

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -3,12 +3,12 @@ project_name = "rukmer-commons"
 environment = "prod"
 client_domain = ""
 allowed_origins = ["http://localhost:4000", ""]
-create_bucket = false
 
+# EC2 Instance and IAM Resources for Session Manager
 instance_name = "you_instance_name"
-existing_bucket_name = "your_existing_bucket_name"
+existing_ec2_role_name = "ask_for_ec2_role_that_lets_ec2_connect_with_session_manager"
+existing_user_group_name = "ask_for_the_group_name_that_allows_iam_users_to_connect_to_ec2"
 
-# Session Manager SSH (recommended approach)
 # Just list your existing IAM usernames - Terraform handles the rest!
 iam_ssh_users = [
   # Example usernames (replace with your actual IAM users):
@@ -21,10 +21,16 @@ iam_ssh_users = [
   # Or check in AWS Console > IAM > Users
 ]
 
-# ---------------------------------------------
-# OPTION: Use Existing IAM Resources (if you get IAM permission errors)
-# ---------------------------------------------
+
+existing_user_group_name = "rukmer_engineers"
+iam_ssh_users = [
+  "yu_lin",
+  "john_solon"
+]
+
+# S3 Bucket for App Assets
+create_bucket = false
+existing_bucket_name = "your_existing_bucket_name"
 
 
-existing_ec2_role_name = "ask_for_ec2_role_that_lets_ec2_connect_with_session_manager"
-existing_user_group_name = "ask_for_the_group_name_that_allows_iam_users_to_connect_to_ec2"
+

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -3,9 +3,14 @@ project_name = "rukmer-commons"
 environment = "prod"
 client_domain = ""
 allowed_origins = ["http://localhost:4000", ""]
-instance_name = "rukmer-commons-ec2-instance"
-allowed_ssh_cidr = "0.0.0.0/0"
-key_pair_name = "rukmer-commons-ec2-key"
 
-# SSH Key Configuration (auto-generated)
-auto_generate_ssh_key = true
+instance_name = "you_instance_name"
+iam_ssh_users = [
+  # Add your existing IAM usernames here:
+  # Everytime a developer deploys, they need to
+  # keep this list updated. Each subsequent deployment
+  # will determine who can SSH into the rukmer-commons-ec2-instance.
+
+  # "your-iam-username",
+  # "coworker-iam-username"
+]

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -46,14 +46,9 @@ variable "instance_name" {
   default     = "my-t2-micro"
 }
 
-variable "key_pair_name" {
-  description = "Name of the AWS key pair for SSH access"
-  type        = string
-  default     = ""
-}
-
-variable "auto_generate_ssh_key" {
-  description = "Whether to auto-generate SSH key pair with Terraform"
-  type        = bool
-  default     = true
+variable "iam_ssh_users" {
+  description = "List of existing IAM usernames for SSH via Session Manager"
+  type        = list(string)
+  default     = []
+  # Example: ["john.doe", "jane.smith"]
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -27,6 +27,12 @@ variable "allowed_origins" {
   default     = []
 }
 
+variable "create_bucket" {
+  description = "Create the S3 bucket"
+  type        = bool
+  default     = false
+}
+
 # ---------------------------------------------
 # EC2 Instance
 # ---------------------------------------------

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -66,8 +66,45 @@ variable "allowed_ssh_cidr" {
 # ---------------------------------------------
 
 variable "iam_ssh_users" {
-  description = "[MODERN] List of existing IAM usernames for SSH via Session Manager"
+  description = <<-EOT
+    [MODERN] List of existing IAM usernames for SSH via Session Manager.
+    
+    How to use:
+    1. Create IAM users in AWS Console (or use existing ones)
+    2. Add their usernames to this list
+    3. Terraform will grant them Session Manager SSH access to your EC2 instance
+    4. Users can SSH using: aws ssm start-session --target INSTANCE_ID
+    
+    Example: ["john.doe", "jane.smith", "developer1"]
+  EOT
   type        = list(string)
   default     = []
-  # Example: ["john.doe", "jane.smith"]
+}
+
+# ---------------------------------------------
+# OPTION: Use Existing IAM Resources (if you don't have IAM create permissions)
+# ---------------------------------------------
+
+variable "use_existing_iam_resources" {
+  description = "Use existing IAM roles/policies instead of creating new ones (useful when you don't have IAM create permissions)"
+  type        = bool
+  default     = true
+}
+
+variable "existing_ec2_role_name" {
+  description = "Name of existing IAM role for EC2 Session Manager (only used if use_existing_iam_resources = true)"
+  type        = string
+  default     = ""
+}
+
+variable "existing_user_policy_arn" {
+  description = "ARN of existing IAM policy for user Session Manager access (only used if use_existing_iam_resources = true)"
+  type        = string
+  default     = ""
+}
+
+variable "existing_user_group_name" {
+  description = "Name of existing IAM group for SSH users (only used if use_existing_iam_resources = true)"
+  type        = string
+  default     = ""
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -16,7 +16,6 @@ variable "environment" {
   default     = "prod"
 }
 
-
 variable "client_domain" {
   description = "Allowed client domain for CORS"
   type        = string
@@ -28,11 +27,15 @@ variable "allowed_origins" {
   default     = []
 }
 
-
-
 # ---------------------------------------------
 # EC2 Instance
 # ---------------------------------------------
+
+variable "enable_backward_compatibility" {
+  description = "Enable backward compatibility"
+  type        = bool
+  default     = true
+}
 
 variable "allowed_ssh_cidr" {
   description = "CIDR block allowed for SSH access"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -27,6 +27,12 @@ variable "allowed_origins" {
   default     = []
 }
 
+variable "create_bucket" {
+  description = "Name of the existing S3 bucket to use for artifacts"
+  type        = boolean
+  default     = false
+}
+
 variable "existing_bucket_name" {
   description = "Name of the existing S3 bucket to use for artifacts"
   type        = string

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -27,10 +27,9 @@ variable "allowed_origins" {
   default     = []
 }
 
-variable "create_bucket" {
-  description = "Create the S3 bucket"
-  type        = bool
-  default     = false
+variable "existing_bucket_name" {
+  description = "Name of the existing S3 bucket to use for artifacts"
+  type        = string
 }
 
 # ---------------------------------------------
@@ -41,23 +40,6 @@ variable "instance_name" {
   description = "Name tag for the EC2 instance"
   type        = string
   default     = "my-t2-micro"
-}
-
-# ---------------------------------------------
-# SSH Access - LEGACY (Traditional SSH) 
-# TODO: DEPRECATE THESE WHEN READY TO REMOVE BACKWARD COMPATIBILITY
-# ---------------------------------------------
-
-variable "enable_backward_compatibility" {
-  description = "[LEGACY] Enable traditional SSH access on port 22 (backward compatibility)"
-  type        = bool
-  default     = true
-}
-
-variable "allowed_ssh_cidr" {
-  description = "[LEGACY] CIDR block allowed for traditional SSH access"
-  type        = string
-  default     = "0.0.0.0/0"  # Restrict this in production
 }
 
 # ---------------------------------------------
@@ -82,29 +64,17 @@ variable "iam_ssh_users" {
 }
 
 # ---------------------------------------------
-# OPTION: Use Existing IAM Resources (if you don't have IAM create permissions)
+# Use Existing IAM Resources (if you don't have IAM create permissions)
 # ---------------------------------------------
 
-variable "use_existing_iam_resources" {
-  description = "Use existing IAM roles/policies instead of creating new ones (useful when you don't have IAM create permissions)"
-  type        = bool
-  default     = true
-}
-
 variable "existing_ec2_role_name" {
-  description = "Name of existing IAM role for EC2 Session Manager (only used if use_existing_iam_resources = true)"
-  type        = string
-  default     = ""
-}
-
-variable "existing_user_policy_arn" {
-  description = "ARN of existing IAM policy for user Session Manager access (only used if use_existing_iam_resources = true)"
+  description = "Name of existing IAM role for EC2 Session Manager"
   type        = string
   default     = ""
 }
 
 variable "existing_user_group_name" {
-  description = "Name of existing IAM group for SSH users (only used if use_existing_iam_resources = true)"
+  description = "Name of existing IAM group for SSH users"
   type        = string
   default     = ""
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -29,7 +29,7 @@ variable "allowed_origins" {
 
 variable "create_bucket" {
   description = "Name of the existing S3 bucket to use for artifacts"
-  type        = boolean
+  type        = bool
   default     = false
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -34,20 +34,8 @@ variable "create_bucket" {
 }
 
 # ---------------------------------------------
-# EC2 Instance
+# EC2 Instance - General Configuration
 # ---------------------------------------------
-
-variable "enable_backward_compatibility" {
-  description = "Enable backward compatibility"
-  type        = bool
-  default     = true
-}
-
-variable "allowed_ssh_cidr" {
-  description = "CIDR block allowed for SSH access"
-  type        = string
-  default     = "0.0.0.0/0"  # Restrict this in production
-}
 
 variable "instance_name" {
   description = "Name tag for the EC2 instance"
@@ -55,8 +43,30 @@ variable "instance_name" {
   default     = "my-t2-micro"
 }
 
+# ---------------------------------------------
+# SSH Access - LEGACY (Traditional SSH) 
+# TODO: DEPRECATE THESE WHEN READY TO REMOVE BACKWARD COMPATIBILITY
+# ---------------------------------------------
+
+variable "enable_backward_compatibility" {
+  description = "[LEGACY] Enable traditional SSH access on port 22 (backward compatibility)"
+  type        = bool
+  default     = true
+}
+
+variable "allowed_ssh_cidr" {
+  description = "[LEGACY] CIDR block allowed for traditional SSH access"
+  type        = string
+  default     = "0.0.0.0/0"  # Restrict this in production
+}
+
+# ---------------------------------------------
+# SSH Access - MODERN (AWS Session Manager)
+# RECOMMENDED: Use this approach for secure SSH access
+# ---------------------------------------------
+
 variable "iam_ssh_users" {
-  description = "List of existing IAM usernames for SSH via Session Manager"
+  description = "[MODERN] List of existing IAM usernames for SSH via Session Manager"
   type        = list(string)
   default     = []
   # Example: ["john.doe", "jane.smith"]


### PR DESCRIPTION
This PR changes the ssh behavior slightly. Previously ssh key pair is generated for each Terraform apply. User then uses generated key pair to authenticate and log into the EC2 instance. This way only works for one user of the EC2 instance. A second user could not generate a private key and login as the way the first user did. The keys pairs won't match.

The new PR proposes to use ssh via AWS managed session manager tool. This is set up once in Terraform. User uses ssh via the Session Manager. The session manager establishes the connection between user and the EC2 instance by verifying each user's unique IAM account.

